### PR TITLE
feat(storefront): BCTHEME-613 Add translations for consent manager

### DIFF
--- a/src/consent-manager/banner.tsx
+++ b/src/consent-manager/banner.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import styled from 'react-emotion'
 import fontStyles from './font-styles'
+import { translations } from './translations-utils'
 
 import { Button } from './buttons'
 
@@ -99,8 +100,10 @@ export default class Banner extends PureComponent<Props> {
           </Content>
 
           <ButtonContainer>
-            <SettingsButton onClick={onChangePreferences}>Settings</SettingsButton>
-            <AcceptButton onClick={onAcceptAll}>Accept All Cookies</AcceptButton>
+            <SettingsButton onClick={onChangePreferences}>
+              {translations.gdpr_settings}
+            </SettingsButton>
+            <AcceptButton onClick={onAcceptAll}>{translations.accept_all_cookies}</AcceptButton>
           </ButtonContainer>
         </div>
       </Root>

--- a/src/consent-manager/cancel-dialog.tsx
+++ b/src/consent-manager/cancel-dialog.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import Dialog from './dialog'
 import styled from 'react-emotion'
 import { Button } from './buttons'
+import { translations } from './translations-utils'
 
 const BackButton = styled(Button)`
   background: none;
@@ -31,8 +32,8 @@ export default class CancelDialog extends PureComponent<Props> {
 
     const buttons = (
       <div>
-        <BackButton onClick={onBack}>Back to Preferences</BackButton>
-        <CloseButton>Close</CloseButton>
+        <BackButton onClick={onBack}>{translations.back_to_preferences}</BackButton>
+        <CloseButton>{translations.cancel}</CloseButton>
       </div>
     )
 

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -3,6 +3,7 @@ import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from './categories'
 import { CategoryPreferences, Destination, ConsentManagerProps } from '../types'
+import {translations} from './translations-utils'
 
 const zeroValuePreferences: CategoryPreferences = {
   marketingAndAnalytics: null,
@@ -21,10 +22,10 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     cookieDomain: undefined,
     customCategories: undefined,
     bannerTextColor: '#fff',
-    bannerSubContent: 'You can change your preferences at any time.',
+    bannerSubContent: translations.change_preferences,
     bannerBackgroundColor: '#1f4160',
-    preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    preferencesDialogTitle: translations.data_collection_preferences,
+    cancelDialogTitle: translations.cancel_dialog_title,
   }
 
   render() {

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'react-emotion'
 import Dialog from './dialog'
 import { Destination, CustomCategories, CategoryPreferences } from '../types'
 import { Button } from './buttons'
+import { translations } from './translations-utils'
 
 const hideOnMobile = css`
   @media (max-width: 600px) {
@@ -85,6 +86,10 @@ const SaveButton = styled(Button)`
   margin-left: 8px;
 `
 
+const categoryPlaceholder = '[CATEGORY_NAME]'
+const replaceWith = (category: string, phrase: string) =>
+  phrase.replace(categoryPlaceholder, category)
+
 interface PreferenceDialogProps {
   innerRef: (element: HTMLElement | null) => void
   onCancel: () => void
@@ -125,11 +130,12 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
       content,
       preferences
     } = this.props
+
     const buttons = (
       <div>
         <div>
-          <CancelButton onClick={onCancel}>Cancel</CancelButton>
-          <SaveButton type="submit">Save</SaveButton>
+          <CancelButton onClick={onCancel}>{translations.cancel}</CancelButton>
+          <SaveButton type="submit">{translations.save}</SaveButton>
         </div>
       </div>
     )
@@ -149,9 +155,9 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">Allow</ColumnHeading>
-                <ColumnHeading scope="col">Category</ColumnHeading>
-                <ColumnHeading scope="col">Purpose</ColumnHeading>
+                <ColumnHeading scope="col">{translations.allow}</ColumnHeading>
+                <ColumnHeading scope="col">{translations.category}</ColumnHeading>
+                <ColumnHeading scope="col">{translations.purpose}</ColumnHeading>
               </Row>
             </thead>
 
@@ -167,10 +173,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="true"
                           checked={functional === true}
                           onChange={this.handleChange}
-                          aria-label="Allow functional tracking"
+                          aria-label={replaceWith(
+                            translations.functional_category,
+                            translations.allow_category_tracking
+                          )}
                           required
                         />{' '}
-                        Yes
+                        {translations.yes}
                       </label>
                       <label>
                         <input
@@ -179,18 +188,18 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="false"
                           checked={functional === false}
                           onChange={this.handleChange}
-                          aria-label="Disallow functional tracking"
+                          aria-label={replaceWith(
+                            translations.functional_category,
+                            translations.disallow_category_tracking
+                          )}
                           required
                         />{' '}
-                        No
+                        {translations.no}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Functional</RowHeading>
+                    <RowHeading scope="row">{translations.functional_category}</RowHeading>
                     <td>
-                      <p>
-                        Enables enhanced functionality, such as videos and live chat. If you do not
-                        allow these, then some or all of these functions may not work properly.
-                      </p>
+                      <p>{translations.functional_purpose}</p>
                     </td>
                   </Row>
 
@@ -203,10 +212,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="true"
                           checked={marketingAndAnalytics === true}
                           onChange={this.handleChange}
-                          aria-label="Allow marketing and analytics tracking"
+                          aria-label={replaceWith(
+                            translations.analytics_category,
+                            translations.allow_category_tracking
+                          )}
                           required
                         />{' '}
-                        Yes
+                        {translations.yes}
                       </label>
                       <label>
                         <input
@@ -215,18 +227,18 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="false"
                           checked={marketingAndAnalytics === false}
                           onChange={this.handleChange}
-                          aria-label="Disallow marketing and analytics tracking"
+                          aria-label={replaceWith(
+                            translations.analytics_category,
+                            translations.disallow_category_tracking
+                          )}
                           required
                         />{' '}
-                        No
+                        {translations.no}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Analytics</RowHeading>
+                    <RowHeading scope="row">{translations.analytics_category}</RowHeading>
                     <td>
-                      <p>
-                        Provide statistical information on site usage, e.g., web analytics so we can
-                        improve this website over time.
-                      </p>
+                      <p>{translations.analytics_purpose}</p>
                     </td>
                   </Row>
 
@@ -239,10 +251,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="true"
                           checked={advertising === true}
                           onChange={this.handleChange}
-                          aria-label="Allow advertising tracking"
+                          aria-label={replaceWith(
+                            translations.advertising_category,
+                            translations.allow_category_tracking
+                          )}
                           required
                         />{' '}
-                        Yes
+                        {translations.yes}
                       </label>
                       <label>
                         <input
@@ -251,18 +266,20 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           value="false"
                           checked={advertising === false}
                           onChange={this.handleChange}
-                          aria-label="Disallow advertising tracking"
+                          aria-label={replaceWith(
+                            translations.advertising_category,
+                            translations.disallow_category_tracking
+                          )}
                           required
                         />{' '}
-                        No
+                        {translations.no}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Targeting; Advertising</RowHeading>
+                    <RowHeading scope="row">
+                      {translations.targeting_category}; {translations.advertising_category}
+                    </RowHeading>
                     <td>
-                      <p>
-                        Used to create profiles or personalize content to enhance your shopping
-                        experience.
-                      </p>
+                      <p>{translations.advertising_purpose}</p>
                     </td>
                   </Row>
                 </>
@@ -283,7 +300,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Allow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          Yes
+                          {translations.yes}
                         </label>
                         <label>
                           <input
@@ -295,7 +312,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Disallow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          No
+                          {translations.no}
                         </label>
                       </InputCell>
                       <RowHeading scope="row">{categoryName}</RowHeading>
@@ -314,12 +331,9 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
 
               <Row>
                 <td>N/A</td>
-                <RowHeading scope="row">Essential</RowHeading>
+                <RowHeading scope="row">{translations.essential_category}</RowHeading>
                 <td>
-                  <p>
-                    Essential for the site and any requested services to work, but do not perform
-                    any additional or secondary function.
-                  </p>
+                  <p>{translations.esential_purpose}</p>
                 </td>
               </Row>
             </tbody>

--- a/src/consent-manager/translations-utils.ts
+++ b/src/consent-manager/translations-utils.ts
@@ -1,0 +1,56 @@
+import {
+  LanguageData,
+  TranslationsDictionary,
+  WindowWithConsentManagerLocalizations
+} from '../types'
+
+// NOTE: below are fallback phrases for consent manager
+const fallbackDictionary: TranslationsDictionary = {
+  cancel: 'Cancel',
+  save: 'Save',
+  allow: 'Allow',
+  accept_all_cookies: 'Accept All Cookies',
+  gdpr_settings: 'Settings',
+  category: 'Category',
+  purpose: 'Purpose',
+  allow_category_tracking: 'Allow [CATEGORY_NAME] tracking',
+  disallow_category_tracking: 'Disallow [CATEGORY_NAME] tracking',
+  functional_category: 'Functional',
+  functional_purpose:
+    'Enables enhanced functionality, such as videos and live chat. If you do not allow these, then some or all of these functions may not work properly.',
+  analytics_category: 'Analytics',
+  analytics_purpose:
+    'Provide statistical information on site usage, e.g., web analytics so we can improve this website over time.',
+  targeting_category: 'Targeting',
+  advertising_category: 'Advertising',
+  advertising_purpose:
+    'Used to create profiles or personalize content to enhance your shopping experience.',
+  essential_category: 'Essential',
+  esential_purpose:
+    'Essential for the site and any requested services to work, but do not perform any additional or secondary function.',
+  yes: 'Yes',
+  no: 'No',
+  change_preferences: 'You can change your preferences at any time',
+  cancel_dialog_title: 'Are you sure you want to cancel?',
+  data_collection_preferences: 'Website Data Collection Preferences',
+  back_to_preferences: 'Back to Preferences'
+}
+const localWindow = window as WindowWithConsentManagerLocalizations
+const createDictionary = (obj: LanguageData): TranslationsDictionary => {
+  const localizedDictionary = obj.translations
+  const translationKeys = Object.keys(localizedDictionary)
+  const isEmpty = !translationKeys.length
+
+  if (isEmpty) return localizedDictionary
+
+  return translationKeys.reduce((dictionary, key) => {
+    dictionary[key.split('.').pop()!] = localizedDictionary[key]
+    return dictionary
+  }, {})
+}
+const composeTranslations = (stringJson: string) => createDictionary(JSON.parse(stringJson))
+const localizedDictionary =
+  localWindow.consentManagerTranslations &&
+  composeTranslations(localWindow.consentManagerTranslations)
+
+export const translations = { ...fallbackDictionary, ...localizedDictionary }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,17 @@ export type WindowWithConsentManagerConfig = Window &
     ) => ConsentManagerInput | ConsentManagerInput
   }
 
+export type WindowWithConsentManagerLocalizations = Window &
+  typeof globalThis & {
+    consentManagerTranslations?: string
+  }
+
 export type ConsentManagerInput = ConsentManagerProps & {
   container: string
+}
+
+export interface TranslationsDictionary {
+  [phrase: string]: string
 }
 
 interface StandaloneConsentManagerParams {
@@ -49,6 +58,12 @@ export interface CategoryPreferences {
   marketingAndAnalytics?: boolean | null | undefined
   advertising?: boolean | null | undefined
   [category: string]: boolean | null | undefined
+}
+
+export interface LanguageData {
+  locale: string
+  locales: TranslationsDictionary | {}
+  translations: TranslationsDictionary
 }
 
 export interface CustomCategories {


### PR DESCRIPTION
@BC-tymurbiedukhin,  @yurytut1993

## What?
This PR adds a translated phrases from theme to consent manager. There is also a fallback phrases in EN that will be caught in case there are no translations available. This will enable merchants to use custom phrases/translations (in case they need) for GDPR/CCPA feature we built to help merchants collect data privacy consent from shopper's on the storefront.

## Why?
This is done under CEV project. There is also related PR on Cornerstone side that can be checked [here](https://github.com/bigcommerce/cornerstone/pull/2083) and [here](https://github.com/bigcommerce/bigcommerce/pull/41564)
Jira tickets can be found [here](https://jira.bigcommerce.com/browse/BCTHEME-603) and [there](https://jira.bigcommerce.com/browse/PROJECT-3950)

## Screenshots 
Phrases are using prefix `lang_DE_` only as an example for visualization.

<img width="1439" alt="translations_consent_manager_1" src="https://user-images.githubusercontent.com/67792608/123246132-23a12380-d4ee-11eb-8ea8-a372a5e46531.png">
<img width="1440" alt="translations_consent_manager_2" src="https://user-images.githubusercontent.com/67792608/123246140-24d25080-d4ee-11eb-8c0b-7a53ddd0659f.png">
<img width="1441" alt="translations_consent_manager_3" src="https://user-images.githubusercontent.com/67792608/123246143-26037d80-d4ee-11eb-84e2-403010ddefdd.png">

## How can this change be undone in case of failure?
Revert this PR


