### PR TITLE
fix(storefront): BCTHEME-715 add styles for consent manager mobile appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Draft
+
+### Added
+
+Added styles for consent banner buttons for mobiles [#7](https://github.com/bigcommerce/consent-manager/pull/7)
+
 ## 4.1.0(Dec 11, 2019)
 
 ### Added

--- a/src/consent-manager/banner.tsx
+++ b/src/consent-manager/banner.tsx
@@ -38,12 +38,26 @@ const P = styled('p')`
   margin: 0;
 `
 const ButtonContainer = styled('div')`
-  display: 'flex';
-  flexdirection: 'row';
-  justifycontent: 'flex-end';
-  flexwrap: 'nowrap';
-  margin: 0;
-  margin-top: 16px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  margin: 16px 0 0;
+
+  @media only screen and (max-width: 400px) {
+    width: 100%;
+    flex-direction: column;
+    justify-content: stretch;
+    align-items: stretch;
+
+    button {
+      margin-left: 0;
+      justify-content: center;
+    }
+    button:nth-child(even) {
+      margin: 8px 0;
+    }
+  }
 `
 
 const SettingsButton = styled(Button)`


### PR DESCRIPTION

#### What?

This PR addresses an issue with consent manager appearance on mobile. In this case, buttons were not aligned and collapsed with each other. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
- [BCTHEME-715](https://jira.bigcommerce.com/browse/BCTHEME-715)


#### Screenshots (if appropriate)
https://user-images.githubusercontent.com/67792608/129223403-6cf0555d-9ea0-4638-b478-87c684f20651.mov




