### PR TITLE
feat(storefront): BCTHEME-810  add custom event on consent permissions change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-Added styles for consent banner buttons for mobiles [#7](https://github.com/bigcommerce/consent-manager/pull/7)
+- Added custom event when consent preferences are changed [#8](https://github.com/bigcommerce/consent-manager/pull/8)
+- Added styles for consent banner buttons for mobiles [#7](https://github.com/bigcommerce/consent-manager/pull/7)
 
 ## 4.1.0(Dec 11, 2019)
 

--- a/src/consent-manager-builder/preferences-utils.ts
+++ b/src/consent-manager-builder/preferences-utils.ts
@@ -1,0 +1,32 @@
+import { transform } from 'lodash'
+import { CategoryPreferences, CustomerPermissions } from '../types'
+
+// Segment preference keys to BC enum taken from consent-manager-config.js
+// if there are custom properties, add them to enum as well
+enum PreferenceMap {
+  functional = 2,
+  marketingAndAnalytics = 3,
+  advertising = 4
+}
+
+function mapCustomerPermissions(
+  customerPermissions: CustomerPermissions,
+  customerPreference: boolean,
+  category: string
+): CustomerPermissions {
+  if (customerPreference) {
+    customerPermissions.allow.push(PreferenceMap[category])
+  } else {
+    customerPermissions.deny.push(PreferenceMap[category])
+  }
+
+  return customerPermissions
+}
+
+const getConsentPreferences = (preferenceObj: CategoryPreferences): CustomerPermissions => {
+  const res: CustomerPermissions = { allow: [], deny: [] }
+
+  return transform(preferenceObj, mapCustomerPermissions, res)
+}
+
+export { getConsentPreferences }

--- a/src/consent-manager/translations-utils.ts
+++ b/src/consent-manager/translations-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import {
   LanguageData,
   TranslationsDictionary,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,11 @@ export interface Preferences {
   customPreferences?: CategoryPreferences
 }
 
+export interface CustomerPermissions {
+  allow: number[]
+  deny: number[]
+}
+
 export interface Destination {
   id: string
   name: string


### PR DESCRIPTION
#### What?

This PR addresses an issue with losing Analytics Referrer context. We implemented a custom event for Consent Manager named `consent_permissions_changed` that will be fired each time when tracking permissions are changed.
In this case we send consent detail object that contains next fields:

- **referrer** _string_
- **allow**  _array[number]_
- **deny** _array[number]_

On the other side, consent data’s consumer can add listener, smth like:

```
const onEvent = (eventType, callback) => document.addEventListener(eventType, callback);
onEvent('consent_permissions_changed', ({ detail }) => {
 // your code here
});
```
**Note:** document element has been used to decouple custom event from specific nodes on the page.

#### Tickets / Documentation
- [BCTHEME-810](https://jira.bigcommerce.com/browse/BCTHEME-810)

#### Screenshots (if appropriate)
Screenshot: on User accepts all cookies
<img width="1679" alt="Screenshot 2021-08-27 at 19 10 29" src="https://user-images.githubusercontent.com/67792608/131333298-c54205bc-62ab-4d7b-acaf-e831f1cd0ce3.png">


Screenshot: User rejects Functional  Category
<img width="764" alt="Screenshot 2021-08-27 at 19 11 21" src="https://user-images.githubusercontent.com/67792608/131333189-2279dae8-39a2-4959-91a8-4f4d04b98872.png">
<img width="1677" alt="Screenshot 2021-08-27 at 19 11 44" src="https://user-images.githubusercontent.com/67792608/131333218-bf5263e3-c6fc-44b8-9dea-df63ccc12f09.png">


