### PR TITLE
BCTHEME-818

### DIFF
--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -57,6 +57,7 @@ const Row = styled('tr')`
     vertical-align: top;
     padding: 8px 12px;
     border: 1px solid rgba(67, 90, 111, 0.114);
+    color: rgb(67, 90, 111);
   }
   td {
     border-top: none;


### PR DESCRIPTION
We have these styles interrupting our own styling

![image](https://user-images.githubusercontent.com/92578518/141261484-e860f10f-98bb-49df-9b2c-313d2fa66e5b.png)


To prevent this we hardcoded color into the component,
now we have something like this

![image](https://user-images.githubusercontent.com/92578518/141261976-5b6d35d4-a711-4d51-899f-462ea57c1426.png)

which ensures that these styles cannot be overwritten by the simple tag selectors