### PR TITLE
BCTHEME-796 updated lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15617,9 +15617,9 @@ next-tick@^1.0.0, next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-"ng-build@github:bigcommerce-labs/ng-build#14.0.10":
+"ng-build@git+ssh://git@github.com:bigcommerce-labs/ng-build.git#14.0.10":
   version "14.0.10"
-  resolved "git+ssh://git@github.com/bigcommerce-labs/ng-build.git#53366df79cba5db81695969d8493180611c34a4e"
+  resolved "git+ssh://git@github.com:bigcommerce-labs/ng-build.git#53366df79cba5db81695969d8493180611c34a4e"
   dependencies:
     "@babel/core" "^7.10.2"
     "@babel/plugin-proposal-class-properties" "^7.10.1"


### PR DESCRIPTION
**What?**
Current yarn lockfile is outdated. We had switched from https to the ssh fetch method. Normally its not an issue, but Circle running yarn with `--frozen-lockfile` flag which assumes lockfile as a source of truth.
This is an issue so had to update it manually.

![image](https://user-images.githubusercontent.com/92578518/145842158-5c01f8ee-cc2f-41ed-abb3-56c0c463c2a3.png)
