### PR TITLE
fix(storefront): BCTHEME-1130 fix consent manager dialog styles for better positioning on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Fixed Consent Manager Dialog styles for better positioning on mobile devices. [#16](https://github.com/bigcommerce/consent-manager/pull/16)
 - Added custom event when consent preferences are changed [#8](https://github.com/bigcommerce/consent-manager/pull/8)
 - Added styles for consent banner buttons for mobiles [#7](https://github.com/bigcommerce/consent-manager/pull/7)
 

--- a/src/consent-manager/dialog.tsx
+++ b/src/consent-manager/dialog.tsx
@@ -38,7 +38,7 @@ const Root = styled<{ width: number | string | undefined }, 'section'>('section'
   display: flex;
   flex-direction: column;
   max-width: calc(100vw - 16px);
-  max-height: calc(100vh - 16px);
+  max-height: calc(100vh - 15%);
   width: ${props => props.width};
   margin: 8px;
   background: #fff;


### PR DESCRIPTION

## What?
Consent Manager Dialog styles have been changed for better positioning on mobile devices.

## Why?
On some mobile devices when Consent Manager Dialog is opened and the option to edit the cookie consent setting is selected the top and bottom of the page is blocked which makes it difficult to close out of the page or save the changes you have selected.

## Testing / Proof
Locally

https://user-images.githubusercontent.com/67792608/194515863-0b079583-2c01-4535-8815-50b20c96b02f.mov



## How can this change be undone in case of failure?

ping https://github.com/orgs/bigcommerce/teams/themes-team

