### PR TITLE
fix(storefront): BCTHEME-1368 remove tracking-preferences cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Removed tracking-preferences cookie in favour of bc_consent cookie. [#17](https://github.com/bigcommerce/consent-manager/pull/17)
 - Fixed Consent Manager Dialog styles for better positioning on mobile devices. [#16](https://github.com/bigcommerce/consent-manager/pull/16)
 - Added custom event when consent preferences are changed [#8](https://github.com/bigcommerce/consent-manager/pull/8)
 - Added styles for consent banner buttons for mobiles [#7](https://github.com/bigcommerce/consent-manager/pull/7)

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -76,4 +76,9 @@ export function savePreferences({
     destinationPreferences,
     customPreferences
   })
+  // NOTE: bc-consent cookie is being used for the same purpose
+  cookies.remove(COOKIE_KEY, {
+    expires: COOKIE_EXPIRES,
+    domain
+  })
 }


### PR DESCRIPTION
#### What?
This PR addresses an issue caused by `tracking-preferences` cookie. Once sub-domain has been applied on Store the mentioned cookie appears on both sub- and root domains.

There is `bc_consent` cookie for tracking User preferences on our side. `tracking-preferences` cookie is a part of original consent manager repo that we've forked. On this basis we can leave only one related cookie which is `bc_consent`.

Video with setting & changing `bc_consent` cookie is attached below.

#### Tickets / Documentation
- [BCTHEME-1368](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1368)

#### Screenshots / Video

https://user-images.githubusercontent.com/67792608/217577574-09e4580d-8f4f-4e16-88b2-05f107f17ba2.mov



[BCTHEME-1368]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ