### PR TITLE
STRF-10995 - Update text in preference dialog box (Targeting & Advertising row)

### DIFF
--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -280,7 +280,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                       </label>
                     </InputCell>
                     <RowHeading scope="row">
-                      {translations.targeting_category};{translations.advertising_category}
+                      {translations.targeting_category}; {translations.advertising_category}
                     </RowHeading>
                     <td>
                       <p>{translations.advertising_purpose}</p>


### PR DESCRIPTION
This is a small cosmetic change to fix the syntax of the "Targeting;Advertising" label in the preference dialog box. The request is to add a space into this label.

It currently displays as:
<img width="760" alt="Screenshot 2023-08-10 at 10 56 29 AM" src="https://github.com/bigcommerce/consent-manager/assets/6527334/d9c87c48-8c43-4602-bcfb-fa828e3cffca">

With this change we will see "Targeting; Advertising".