### PR TITLE
feat(analytics): DATA-11730 Trigger BODL consent events

### DIFF
--- a/src/bodl/Bodl.ts
+++ b/src/bodl/Bodl.ts
@@ -1,0 +1,36 @@
+import { CategoryPreferences } from '../types'
+import { BodlConsentPayload, BodlEvents, WindowWithBodlEvents } from './types'
+
+class BODL {
+  private readonly bodlEvents?: BodlEvents
+
+  constructor() {
+    const windowWithBodl = window as WindowWithBodlEvents
+    this.bodlEvents = windowWithBodl.bodlEvents
+  }
+
+  public emitConsentLoadedEvent(preferences: CategoryPreferences | undefined) {
+    if (this.bodlEvents) {
+      this.bodlEvents.consent.emitConsentLoadedEvent(this.prepareBodlPayload(preferences))
+    }
+  }
+
+  public emitConsentUpdatedEvent(preferences: CategoryPreferences | undefined) {
+    if (this.bodlEvents) {
+      this.bodlEvents.consent.emitConsentUpdatedEvent(this.prepareBodlPayload(preferences))
+    }
+  }
+
+  private prepareBodlPayload(preferences: CategoryPreferences | undefined): BodlConsentPayload {
+    const { advertising = false, functional = false, marketingAndAnalytics: analytics = false } =
+      preferences || {}
+
+    return {
+      advertising: Boolean(advertising),
+      functional: Boolean(functional),
+      analytics: Boolean(analytics)
+    }
+  }
+}
+
+export const bodl = new BODL()

--- a/src/bodl/types.ts
+++ b/src/bodl/types.ts
@@ -1,0 +1,17 @@
+export interface BodlConsentPayload {
+  advertising: boolean
+  analytics: boolean
+  functional: boolean
+}
+
+export interface BodlEvents {
+  consent: {
+    emitConsentLoadedEvent: (payload: BodlConsentPayload) => void
+    emitConsentUpdatedEvent: (payload: BodlConsentPayload) => void
+  }
+}
+
+export type WindowWithBodlEvents = Window &
+  typeof globalThis & {
+    bodlEvents?: BodlEvents
+  }

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -6,6 +6,7 @@ import conditionallyLoadAnalytics from './analytics'
 import fetchDestinations from './fetch-destinations'
 import { loadPreferences, savePreferences } from './preferences'
 import { getConsentPreferences } from './preferences-utils'
+import { bodl } from '../bodl/Bodl'
 
 function getNewDestinations(destinations: Destination[], preferences: CategoryPreferences) {
   const newDestinations: Destination[] = []
@@ -151,6 +152,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     } = this.props
     // TODO: add option to run mapCustomPreferences on load so that the destination preferences automatically get updated
     let { destinationPreferences = {}, customPreferences } = loadPreferences()
+
+    bodl.emitConsentLoadedEvent(customPreferences)
 
     const [isConsentRequired, destinations] = await Promise.all([
       shouldRequireConsent(),

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events'
 import cookies from 'js-cookie'
 
 import { WindowWithAJS, Preferences, CategoryPreferences } from '../types'
+import { bodl } from '../bodl/Bodl'
 
 const COOKIE_KEY = 'tracking-preferences'
 // TODO: Make cookie expiration configurable
@@ -76,4 +77,6 @@ export function savePreferences({
     destinationPreferences,
     customPreferences
   })
+
+  bodl.emitConsentUpdatedEvent(customPreferences)
 }


### PR DESCRIPTION
## What [DATA-11730](https://bigcommercecloud.atlassian.net/browse/DATA-11730)
- Introduce BODL emitter
- Emit `ConsentLoadedEvent` BODL event
- Emit `ConsentUpdatedEvent` BODL event

## Why
As a part of new `GA4 consent mode` project we need to introduce 2 new BODL events. So that GA4 (or anyone else) can subscribe on that and send specific events to with selected consent permissions.

[DATA-11730]: https://bigcommercecloud.atlassian.net/browse/DATA-11730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ